### PR TITLE
fix text the about page

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -45,7 +45,10 @@
   </nav>
 
   <section id="whoWeServe">
-    <div class="block-text-header">WHO WE SERVE</div>
+    <div class="block-text-header">
+      <span>WHO</span>
+      WE SERVE
+    </div>
     <hr />
     <p class="block-text">
       Your donations make a significant impact in our healthcare efforts in
@@ -69,13 +72,16 @@
   </section>
 
   <section id="whoWeAre">
-    <div class="block-text-header">WHO WE ARE</div>
+    <div class="block-text-header">
+      <span>WHO</span>
+      WE ARE
+    </div>
     <hr />
     <!-- Do we need to do this with HRs or can we just do a border style on the Block text header , I feel like the hr is not really needed, if its just a visual component-->
     <div class="vision-values-block">
       <div>
         <h2>Vision</h2>
-        <p>
+        <p class="block-text">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Mattis
           aliquam faucibus purus in massa tempor nec feugiat nisl. Amet
@@ -97,7 +103,7 @@
 
       <div>
         <h2>Values</h2>
-        <p>
+        <p class="block-text">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Mattis
           aliquam faucibus purus in massa tempor nec feugiat nisl. Amet
@@ -117,8 +123,10 @@
         </p>
       </div>
     </div>
+
+    <div class="statement">
     <h2>Statement of Faith</h2>
-    <ol>
+    <ol class="faith">
       <li>
         We believe the Bible to be the inspired, authoritative Word of God,
         useful to teach us truth about God and His love, and to correct us
@@ -144,10 +152,14 @@
         judgment.
       </li>
     </ol>
+  </div>
   </section>
 
   <section id="boardMembers">
-    <div class="block-text-header">BOARD MEMBERS</div>
+    <div class="block-text-header">
+      <span>BOARD</span>
+      MEMBERS
+    </div>
     <hr />
     <div class="boardMember_wrapper">
       <div class="boardMember_card">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -688,23 +688,57 @@ footer .footer__text {
 /* ABOUT PAGE */
 
 #whoWeServe {
-  margin-top: 15%;
+  margin-top: 12%;
 }
 
 #whoWeServe p {
   text-align: left;
   font-family: "Raleway", sans-serif;
-  text-align: left;
   column-count: 2;
   margin: 30px 45px 20px 35px;
+  padding: 50px 20px 30px 20px;
+  column-gap: 50px;
+}
+
+#whoWeAre {
+  margin-top: 2%;
+}
+
+.vision-values-block {
+  text-align: left;
+  margin: 30px auto;
+}
+
+.vision-values-block p {
+  font-family: "Raleway", sans-serif;
+  overflow-wrap: normal;
+  font-weight: 500;
+  font-size: 18px; 
+}
+
+.statement {
+  margin: 0 30px;
   padding: 0 20px;
+}
+.faith li {
+  font-family: "Raleway", sans-serif;
+  overflow-wrap: normal;
+  font-weight: 500;
+  font-size: 18px; 
+}
+
+#boardMembers {
+  margin-top: 5%;
 }
 
 .boardMember_wrapper {
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-top: 40px;
+  margin-bottom: 40px;
 }
+
 .boardMember_card {
   display: flex;
   flex-direction: column;
@@ -717,19 +751,44 @@ footer .footer__text {
   box-shadow: 0 8px 36px 0 #404045;
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
-  height: 650px;
+  height: 1000px;
 }
 
+.boardMember_bio {
+  font-family: "Raleway", sans-serif;
+  overflow-wrap: normal;
+  font-weight: 500;
+  font-size: 18px; 
+}
+
+
 /* UTILITY CSS */
+
+.block-text-header {
+  line-height: 1.1;
+  font-size: 75px;
+  margin-top: 30px;
+  margin-bottom: 35px;
+  flex: 1;
+  font-weight: 400;
+  font-family: "Bebas Neue", cursive, sans-serif;
+  text-align: center;
+}
+
+.block-text-header span {
+  color: var(--accent-color);
+}
 
 .block-text {
   margin: 10px 0 30px;
   padding: 0 10px;
+  overflow-wrap: normal;
+  font-weight: 500;
+  font-size: 18px;
 }
 
-.block-text-header {
-  font-size: xx-large;
-  padding: 0 10px;
+h2 {
+  font-family: "Bebas Neue", cursive, sans-serif;
 }
 
 /* Our Team */
@@ -766,7 +825,7 @@ footer .footer__text {
   overflow-wrap: normal;
   text-align: left;
   font-weight: 500;
-  font-size: 20px;
+  font-size: 18px;
 }
 
 /* Flip Card */
@@ -904,7 +963,7 @@ footer .footer__text {
   overflow-wrap: normal;
   text-align: left;
   font-weight: 500;
-  font-size: 20px;
+  font-size: 18px;
 }
 
 .public-documents__body a i {


### PR DESCRIPTION

Hi @Iconians, I notice a few things on mobile responsive:
Way To Heath text on the nav bar becomes too big
Who We Serve  - the title disappears - hidden behind the nav bar 
Board Members card - the card is not responsive and not going down as a single card.
And since the card height is fixed the texts are overflowing outside the border, I have tried to fix this multiple ways but so far no luck.
I try the flex-direction: row - the responsive seems to work this way.
I think since the the card has a lot of text might be good to break it down into 2 columns & 2 rows, so the box does not look so thin & long. 
Thanks.